### PR TITLE
Add more obvious link to FAQ

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -19,6 +19,8 @@ Some were created by 18F, and some are documents 18F made in collaboration with 
 
 These documents are from various organizations using various approaches to solve their problems. None of these documents represent the "ideal" process, but we hope that you can use these real-world examples as templates and modify them as needed. Similarly, this collection doesn't contain everything you need to know. Some of these documents even contain comments pointing out areas that could be improved, or areas where more thought is needed. We wanted to be transparent with you and show the thought process behind what you read here. But, it's a good place to start to help your organization move from waterfall and monolithic approaches to modular contracting.
 
+As you begin, you may have questions. We've answered some [frequently asked questions](/faq/) to address some common concerns.
+
 ---
 
 ## Product strategy

--- a/pages/home.md
+++ b/pages/home.md
@@ -19,7 +19,7 @@ Some were created by 18F, and some are documents 18F made in collaboration with 
 
 These documents are from various organizations using various approaches to solve their problems. None of these documents represent the "ideal" process, but we hope that you can use these real-world examples as templates and modify them as needed. Similarly, this collection doesn't contain everything you need to know. Some of these documents even contain comments pointing out areas that could be improved, or areas where more thought is needed. We wanted to be transparent with you and show the thought process behind what you read here. But, it's a good place to start to help your organization move from waterfall and monolithic approaches to modular contracting.
 
-As you begin, you may have questions. We've answered some [frequently asked questions](/faq/) to address some common concerns.
+As you begin, you may have questions. We've answered some [frequently asked questions about agile development, modular procurement, open source, and Commercial Off The Shelf (COTS) software](/faq/) to address some common concerns.
 
 ---
 


### PR DESCRIPTION
Trying to make the FAQ stand out a bit more. This isn't as good as incorporating the content into more appropriate areas, but could be a start.

I'm also not sure whether this should actually go down below in one of the lists.