### PR TITLE
Changed navigation in site header

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -1,51 +1,39 @@
 assigned:
+    # -
+    #     text: About
+    #     href: pages/about.md
+    #     permalink: /about/
+    #     show_in_menu: true
+    #     show_in_footer: false
     -
-        text: Home
-        href: pages/home.md
-        permalink: /
+        text: 'Agile Development'
+        href: pages/agile-development.md
+        permalink: /agile-development/
         show_in_menu: true
         show_in_footer: false
     -
-        text: About
-        href: pages/about.md
-        permalink: /about/
+        text: 'Modular Procurement'
+        href: pages/modular-procurement.md
+        permalink: /modular-procurement/
+        show_in_menu: true
+        show_in_footer: false
+    -
+        text: 'Open Source'
+        href: pages/open-source.md
+        permalink: /open-source/
+        show_in_menu: true
+        show_in_footer: false
+    -
+        text: 'Using COTS'
+        href: pages/using-cots.md
+        permalink: /using-cots/
         show_in_menu: true
         show_in_footer: false
     -
         text: FAQ
-        href: pages/faq.md
-        permalink: /faq/
+        href: pages/common-questions.md
+        permalink: /common-questions/
         show_in_menu: true
         show_in_footer: false
-        children:
-            -
-                text: 'Agile Development'
-                href: pages/agile-development.md
-                show_in_menu: true
-                show_in_footer: false
-            -
-                text: 'Modular Procurement'
-                href: pages/modular-procurement.md
-                show_in_menu: true
-                show_in_footer: false
-            -
-                text: 'Open Source'
-                href: pages/open-source.md
-                show_in_menu: true
-                show_in_footer: false
-            -
-                text: 'Using COTS'
-                href: pages/using-cots.md
-                show_in_menu: true
-                show_in_footer: false
-            -
-                text: 'Common Questions'
-                href: pages/common-questions.md
-                show_in_menu: true
-                show_in_footer: false
-    -
-        text: 'Project data'
-        href: _data/projects.yml
-        show_in_menu: false
-        show_in_footer: false
+
 unassigned: []

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,6 +25,11 @@ layout: base
         <a href="{{ page.banner-button-link }}" class="usa-button">{{ page.banner-button-text }}</a>
       </div>
       {% endif %}
+      {% if page.banner-video-url %}
+      <div>
+        <iframe width="560" height="315" src="{{page.banner-video-url}}" frameborder="0" allowfullscreen></iframe>
+      </div>
+      {% endif %}
     </div>
   </div>
 </section>
@@ -38,7 +43,7 @@ layout: base
         {% if page.content-button-link %}
           <a href="{{ page.content-button-link | prepend: site.baseurl }}" class="usa-button">{{ page.content-button-text }}</a>
         {% endif %}
-      </div>  
+      </div>
     </div>
   </div>
 </section>

--- a/_sass/_banners.scss
+++ b/_sass/_banners.scss
@@ -6,11 +6,11 @@
 }
 .banner.tagline p {
   color: $banner-text-color;
-  margin-bottom: 75px;
+  margin-bottom: 25px;
 }
 .banner.tagline h2 {
   color: $banner-text-color;
-  margin-top: 75px;
+  margin-top: 25px;
 }
 
 .banner.contact {

--- a/pages/agile-development.md
+++ b/pages/agile-development.md
@@ -1,0 +1,39 @@
+---
+layout: project-list
+title: Agile development processes
+permalink: /agile-development/
+---
+
+Agile development describes a set of principles for building software that allow collaborative, cross-functional teams to accommodate changing user needs and requirements.
+
+One of the great strengths of agile development is that delivery is incremental, which spreads the risk across the entire development process rather than loading all of it at the very end. When things go wrong, they’re smaller problems that can be fixed more quickly and more easily.
+
+#### Agile development is based on the reality that you will discover new requirements during the development process.
+
+In any complex system, needs change, evolve, or are discovered over time. Instead of ignoring these changing needs, or going through a painful contract amendment and renegotiation process, we embrace the concept that we will discover new requirements as we go.
+
+To help this process, we pair identifying requirements at a higher level (an “epic” in agile terminology) with an ongoing user research process. These epics describe the user need, not the solution. Through the user research process, these epics are turned into a set of increasingly-specific user stories. This is done continuously, so that user stories are ready for the development team no more than a month ahead of when the development team implements them. (For example, a user story might be: “As a caseworker, I want to see all my current cases and next steps so I know what I need to do next, and when I need to do it.” We wouldn't write: “The system shall display the next step next to each case in a grid on the main screen.”)
+
+There are three leading causes why IT projects fail: a lack of reliable input from users, incomplete requirements and specifications, and changes in the requirements and specifications. The Standish Group, an IT research firm, publishes an annual report on IT projects, in which they point out that these causes of failure are about the impossibility of “knowing” requirements up front.
+
+#### Agile development requires a shift in how you understand the costs of software development.
+
+The traditional “waterfall” method of software development assumes that software can be built once for a large, one-time investment. In practice, this is untrue, because requirements can rarely be fully known and change constantly. Users' needs tend to arise through research and testing, and development teams must discover appropriate solutions by building iteratively and interacting with users regularly.
+
+Ultimately, the state’s investment should be measured in working software, not phase documents or milestones. Only working systems are of value to real constituents. Based on that premise, teams are only able to measure the success of a waterfall project after most costs have been incurred, because that is the first time working software is delivered. This is a huge risk. Agile projects allow the state to measure success at more regular intervals, and reduce the overall risk to the state.
+
+#### Starting with small projects can help build agile project management skills.
+
+We recommend starting with a small, less important project in order to develop your team’s understanding of agile project management, then expand. It is certainly much more difficult (and higher risk), and requires more coaching and training, to dive right into a large, high profile, critical project first.
+
+#### Incremental development can allow end users to start seeing benefits even before the legacy system can be fully replaced.
+
+Old systems must be kept up until the new system is fully operational, no matter what approach is used. In a monolithic approach, the end user must wait many months or years to use the new system and see any benefit — and that’s assuming there are no problems with the rollout. In an incremental approach, the end user could start seeing benefits in weeks. Depending on the architecture of the legacy system, parts of it may even be able to be decommissioned and turned off before the full new system is in place to save money.
+
+#### Agile principles recommend documentation that supports long-term maintenance.
+
+One common misconception about agile development, which calls for _just enough_ documentation, is that there will be _no_ documentation. That is not true: agile prescribes documentation that is of value to the long-term team.
+
+#### Like any process, agile development has risks — but they are avoidable.
+
+In some cases, teams incorrectly using agile as justification for poor or no architecture, design, or documentation. Incomplete, incorrect, or uninformed adoption of agile techniques can lead to an ineffective process we call “agilefall.” We've written a blog post about [how to avoid this pitfall](https://18f.gsa.gov/2015/12/29/is-your-project-using-agilefall/).

--- a/pages/common-questions.md
+++ b/pages/common-questions.md
@@ -1,0 +1,99 @@
+---
+layout: project-list
+title: Common questions from state partners
+permalink: /common-questions/
+---
+
+There are a number of questions and concerns we've heard expressed in many of our workshops and conversations. Here's how we answer a few of them:
+
+#### How do we evaluate vendors if they don’t estimate costs up front and the deliverables aren’t fixed? How is this better than knowing upfront costs and all deliverables and timelines?
+
+Vendors would still be submitting proposals with associated costs, deliverables, etc. The difference with modular procurement is that what they are proposing against is much smaller and more frequent.
+
+#### The federal government has up to 60 days to approve our Advance Planning Documents and our RFPs for projects involving federal grants. Doing more small procurements just means more delay. How can that be improved?
+
+18F is committed to working with our federal partners to reduce the burden on state agencies to get smaller contracts approved. The approval cycle is to ensure that states are mitigating risk—and one of the best ways to do that is with shorter, lower-cost contracts.
+
+#### Can I just buy off 18Fs Agile Blanket Purchase Agreement (BPA)?
+
+18F’s Agile BPA is only available for use by 18F and its partner agencies. As 18F can directly support states by establishing an Intergovernmental Cooperative Agreement with them, then any state or local entity can avail themselves of the services offered on it.
+
+#### Who will I call when something goes wrong after launch?
+
+We work to ensure that an appropriate acquisition plan is in place, so that an open source solution will be maintained, just like closed source software.
+
+#### How can we ensure accountability without having a single systems integrator?
+
+Paradoxically, the idea that a single systems integrator provides ultimate accountability and maximum control isn’t supported by decades of large-scale IT projects that used this approach. In the same way that most manufacturing companies rely on multiple suppliers, companies that need digital products have expanded their procurement practices with multisourcing, to reduce the type of risk that comes from vendor lock-in with a single systems integrator.
+
+#### Agile seems to require different skills of my staff, how do I know what skill we need in house and how do we get that training? Or can I hire a vendor to do that?
+
+This is where 18F, in particular, can help the most.
+
+#### Our mainframe is 30 years old and I can’t risk doing anything to make it stop working because it’s the only thing we have that works.
+
+We can help you identify strategies to mitigate the risks of moving away from a legacy mainframe system. For example:
+
+* Mainframes are designed to be highly efficient in executing very specific functions; split those functions out one by one and replace them.
+* Use proxies to abstract out new code from legacy code.
+* Ensure there are swift fallback/reversion processes in place as you migrate.
+* Use agile prioritization techniques to identify priorities for the migration process, taking into consideration risk, timing, effort, and benefit.
+
+The key to success is migrating piece by piece. Aiming to do a single cut over to a new system is extremely risky.
+
+#### How do we hold vendors accountable without traditional requirements documentation?
+
+Documentation as the bedrock of oversight is an artifact of waterfall development, because there's no product to assess or examine until the end of the project. Agile IV&V must concentrate on evaluating the actual product, each sprint, throughout the development period.
+
+Within the agile process, expectations are managed by having incremental releases. Working software (or lack thereof) is the measure of a vendor's performance. A good vendor is not just one that delivers software functionality, but can also easily adapt to changing needs.
+
+#### Once we hire an agile vendor, how do we know they’re going to deliver what we want?
+
+Vendors that can do agile work will respond to the way you are working. We recommend having an empowered product owner — a single person who acts as the point of contact for the vendor, and who can serve as a zealous advocate for the success of the project. In a well-run agile project you will get working product from your vendors every two weeks. If you don’t, then you have a problem. If you do, then you can evaluate their deliverables every two weeks
+
+#### What about governance? And IV&V? How does that work with agile development?
+
+In a well-run agile project you will get working product from your vendors every two weeks. If you don’t, then you have a problem. If you do, then you can evaluate their deliverables every two weeks.
+
+#### What happens if something goes wrong?
+
+If you discover a bug in the software, you hire a vendor to fix it. It doesn’t have to be the same vendor that originally produced the code. In fact, the bug could simply be added to the product backlog and the next vendor would pick it up.
+
+If a vendor isn’t producing to the level you expect, you can simply not hire them for any subsequent work. The amount of time and effort lost is limited to that one development period, possibly as short as a few weeks, rather than the entire life of the project.
+
+
+#### How do we deal with so many vendors? What if they use different languages and we don’t have staff familiar with those.
+
+You would ensure that the vendors:
+
+- Build to common standards that are determined and controlled either by the state or by the entire technical project team
+- Build with agreed engineering practices across the entire program
+- Use IV&V to monitor consistency across teams
+- Use project-wide "Definition of Ready" and "Definition of Done"
+- Organize by "Feature Teams"
+- Conduct synchronized, system-wide sprint reviews
+- Maintain standards for automated test
+- Deliver code with good test coverage
+- Use current and popular languages, tools and frameworks
+- Include “non-functional requirements (NFRs)” in all solicitations, specifying required technology stack, tools, and other technical constraints
+
+#### Let’s say we build a new system with 12 modules, how do we maintain that system? Do we keep all of those vendors on board through the life of the project?
+
+No. If the modules are open source and built with standard languages, libraries, and frameworks, other vendors can jump in to add features or make fixes as necessary. This frees the state from having to rely on any given vendor for anything as new vendors can swap in and out.
+
+With iterative and incremental goals of agile development, continuous integration and continuous deployment activities become de facto needs of systems.  As a result, comprehensive automation (testing and deployment) becomes baked in as part of the development process.  This automation helps reduce the reliance on institutional knowledge from vendors leading to the reduction of barriers to entry for other vendors to maintain the system.  Increasing competition amongst vendors and thus keeping costs down to the state.
+
+#### What happens when something goes wrong and vendors all blame each other? How does the problem get fixed quickly and who pays for that?
+
+With every release, you would have deployed code that is tested in the field. You could have an acceptance period. The state would be responsible for problems discovered after this period. It would be treated as fresh development that can be contracted out to any developer. This is a fact of (software development) life that has to be accepted.
+
+
+#### How do all these modules really fit together?
+
+There are two distinct levels of “fitting together.”
+* One is at the user interface level where good and consistent application of HCD principles across all modules will provide similar user experiences to people using each module. For instance, if I have to look up a person, the presentation of that person’s information should look the same regardless of which module I am currently working in.
+* The second “fitting together” is at the technical level, and this is a key point. _The modules need not know about each other at all._ Each module should communicate directly with the database and act directly on data. There should be no need for “integration” between modules. So the modules fit together by operating on the same data independently.
+
+#### Who is the system integrator? The state? A vendor? How does this work?
+
+Just as the role of Project Manager changes in an agile project, so does the role of system integrator. The state can become the system integrator if there is the will and the budget, a system integrator can be engaged as in the past, or you can take advantage of the agile approach and not use a system integrator. There will be a few things that require an overall project view that require some technical expertise, but they will be orders of magnitude less than with a multi-vendor waterfall project.

--- a/pages/home.md
+++ b/pages/home.md
@@ -3,30 +3,29 @@ layout: home
 permalink: /
 hero-image: /assets/img/feature-background.jpg
 hero-text: 'Learn to implement modular contracting and agile development in your government organization.'
-banner-heading: 'What is modular contracting? Why should I care?'
-banner-text: 'Modular contracting reduces vendor lock-in, the risk of failure, and the consequences of failure, while enabling continuous competition and allowing your end users to benefit from new software in weeks — not years. It does this by breaking up a massive software project into smaller pieces and issuing multiple smaller, faster, lower-risk solicitations.'
-banner-button-text: Learn how to lower your procurement risk
-banner-button-link: "https://pages.18f.gov/digital-acquisition-playbook/"
+banner-heading: 'What is modular contracting?'
+banner-text: 'Modular contracting is an acquisition strategy that breaks up large, complex procurements into multiple, tightly-scoped projects to implement technology systems in successive, interoperable increments. It is an approach that can help reduce vendor lock in, mitigate risk, and encourage the delivery of working software to users more rapidly.'
+#banner-button-text: Learn how to lower your procurement risk
+#banner-button-link: "https://pages.18f.gov/digital-acquisition-playbook/"
+banner-video-url: https://www.youtube.com/embed/lNSmF7-xisU
 
 ---
 # Modular contracting and agile development
 
-## What is this page?
-
 Below, you'll find a collection of resources to help you understand what modular contracting is, how to implement modular contracting in your organization, and how modular contracting can enable agile development. There are presentations and white papers, but a majority of these are real RFPs, quality assurance surveillance plans, questions and answers, vendor prototype challenge solicitations, evaluation factors, statements of work, and more.
 
-Some were created by 18F, and some are documents 18F made in collaboration with our partners. We hope that as more agencies use modular contracts, agile vendor pools, and develop software using agile methodologies, they'll submit (via [pull request](https://github.com/18F/Modular-Contracting-And-Agile-Development), please!) their own documents for inclusion in this guide.
+Some were created by 18F, and some are documents 18F made in collaboration with our partners. We hope that as more agencies use modular contracts, agile vendor pools, and develop software using agile methodologies, they'll submit (via [pull request](https://github.com/18F/Modular-Contracting-And-Agile-Development/pulls), please!) their own documents for inclusion in this guide.
 
 These documents are from various organizations using various approaches to solve their problems. None of these documents represent the "ideal" process, but we hope that you can use these real-world examples as templates and modify them as needed. Similarly, this collection doesn't contain everything you need to know. Some of these documents even contain comments pointing out areas that could be improved, or areas where more thought is needed. We wanted to be transparent with you and show the thought process behind what you read here. But, it's a good place to start to help your organization move from waterfall and monolithic approaches to modular contracting.
 
-As you begin, you may have questions. We've answered some [frequently asked questions about agile development, modular procurement, open source, and Commercial Off The Shelf (COTS) software](/faq/) to address some common concerns.
+As you begin, you may have questions. We've answered some [frequently asked questions](/common-questions/) about agile development, modular procurement, open source, and Commercial Off The Shelf (COTS) software to address some common concerns.
 
 ---
 
 ## Product strategy
 
 * [United States Digital Service: Digital Services Playbook](https://playbook.cio.gov/). Too many of our digital services projects do not work well, are delivered late, or are over budget. To increase the success rate of these projects, the U.S. government needs a new approach. The United States Digital Service created a playbook of 13 key “plays” drawn from successful practices from the private sector and government that, if followed together, will help government build effective digital services.
-* [The Twelve-Factor App](https://12factor.net/). This is a list of 12 different “factors” that an organization should employ when building a software as a service application. Employing these 12 factors will help minimize time and cost for new developers joining the project, offer maximum portability between environments, be deployable on modern cloud platforms, enable continuous deployment for maximum agility, and can scale up without significant changes. 
+* [The Twelve-Factor App](https://12factor.net/). This is a list of 12 different “factors” that an organization should employ when building a software as a service application. Employing these 12 factors will help minimize time and cost for new developers joining the project, offer maximum portability between environments, be deployable on modern cloud platforms, enable continuous deployment for maximum agility, and can scale up without significant changes.
 
 ## Presentations
 
@@ -36,7 +35,7 @@ As you begin, you may have questions. We've answered some [frequently asked ques
 
 * [Strangler Pattern](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Presentation%20Strangler%20Pattern.pdf). An 18F presentation explaining a software development technique called the Strangler (or Encapsulation) Pattern, an approach for gradually migrating organizations off legacy systems, avoiding "big bang" deployments, and drastically decreasing how long it takes end users to begin using the new system.
 
-* [Agile and Scrum for New Teams](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Presentation%20Agile%20and%20Scrum%20for%20New%20Teams.pdf). A presentation that accompanies a day-long 18F "Introduction to Agile and Scrum" workshop. 
+* [Agile and Scrum for New Teams](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Presentation%20Agile%20and%20Scrum%20for%20New%20Teams.pdf). A presentation that accompanies a day-long 18F "Introduction to Agile and Scrum" workshop.
 
 * [Human-Centered Design and Agile](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Presentation%20Human%20Centered%20Design%20and%20Agile.pdf). An 18F presentation introducing human-centered design and how it relates to agile software development.
 
@@ -52,13 +51,13 @@ As you begin, you may have questions. We've answered some [frequently asked ques
 
 ### Agile Vendor Pool
 
-* [California Agile Vendor Pool RFI](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/California%20Vendor%20Pool%20RFI.pdf) This is the RFI California used to gather information when they were creating their Agile Vendor Pool. 
+* [California Agile Vendor Pool RFI](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/California%20Vendor%20Pool%20RFI.pdf) This is the RFI California used to gather information when they were creating their Agile Vendor Pool.
 
 * [18F Agile Vendor Pool RFQ](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/18F%20Agile%20Vendor%20Pool%20RFQ.docx). This is the RFQ 18F used when creating our Agile Vendor Pool, also referred to as a BPA (Blanket Purchase Agreement).
 
 * [Mississippi Agile Vendor Pool RFP](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Mississippi%20Agile%20Vendor%20Pool%20RFP.docx). This is the RFP Mississippi used when creating their Agile Vendor Pool. It includes a lot of state-specific boilerplate language.
 
-* [Mississippi Agile Vendor Pool RFP Lightweight Version](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Mississippi%20Agile%20Vendor%20Pool%20RFP%20Lightweight%20version.docx). This is a lightweight version of the Mississippi Agile Vendor Pool, before state boilerplate language was inserted. 
+* [Mississippi Agile Vendor Pool RFP Lightweight Version](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Mississippi%20Agile%20Vendor%20Pool%20RFP%20Lightweight%20version.docx). This is a lightweight version of the Mississippi Agile Vendor Pool, before state boilerplate language was inserted.
 
 * [Mississippi Potential RFP questions](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/Mississippi%20Potential%20Vendor%20Questions%20for%20Vendor%20Pool%20RFP.xlsx). These were a list of questions Mississippi wanted to ensure were answered in their RFP, gathered largely from vendor questions California and 18F recieved when creating their Agile Vendor Pools.
 
@@ -80,4 +79,4 @@ As you begin, you may have questions. We've answered some [frequently asked ques
 
 * [California Intake Module Statement of Work](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/California%20Intake%20Module%20Statement%20of%20Work.docx). This is the solicitation California sent to their agile vendor pool for the Intake module of their child welfare system replacement.
 
-* [California Nonfunctional Requirements](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/California%20Nonfunctional%20Requirements.docx). These are the non-functional, technical requirements that California included in their solicitations to the agile vendor pool. 
+* [California Nonfunctional Requirements](https://github.com/18F/Modular-Contracting-And-Agile-Development/raw/master/pages/files/California%20Nonfunctional%20Requirements.docx). These are the non-functional, technical requirements that California included in their solicitations to the agile vendor pool.

--- a/pages/modular-procurement.md
+++ b/pages/modular-procurement.md
@@ -1,0 +1,47 @@
+---
+layout: project-list
+title: Managing modular procurements
+permalink: /modular-procurement/
+---
+
+Modular procurement is a procurement model that breaks what would traditionally be a large, monolithic contract into several shorter-term, lower dollar amount contracts.
+
+Modular procurement does two things that make it easier to manage development: it segments risks and increases transparency. Segmenting risk means that what was a single, monolithic project is handled as smaller, discrete units. If one unit fails, that failure is isolated. Because each project is smaller, they are easier to comprehend and manage, making problems and risks smaller so you can recognize and resolve them more easily.
+
+In practice, most traditional contracts already have multiple companies responsible for different parts of the effort, but you may not see that complexity until something goes wrong. The majority of large scale government IT projects fail, so it’s nearly inevitable that something will go wrong under a traditional procurement process.
+
+The [Standish Group found](http://www.computerworld.com/article/2486426/healthcare-it/healthcare-gov-website--didn-t-have-a-chance-in-hell-.html) that:
+
+> Of 3,555 projects from 2003 to 2012 that had labor costs of at least $10 million, only 6.4% were successful. The Standish data showed that 52% of the large projects were "challenged," meaning they were over budget, behind schedule or didn't meet user expectations. The remaining 41.4% were failures — they were either abandoned or started anew from scratch.
+
+
+#### Modular procurement doesn't necessarily mean more work for your procurement team.
+
+You do need to do some work up-front to change your procurement processes to support modular procurement. Modular procurement can actually reduce the work required, such as by simplifying vendor selection and speeding up the process.
+
+#### Shorter contracts will reduce the risk of factors beyond your control.
+
+Planning work for a successful six-month contract is easier than planning a successful six-year contract.
+
+At its core, modular procurement supports iterative development. This means that you are continuously improving, rather than merely hoping for perfection at some point in the future. Building a Minimal Viable Product (MVP) and learning from it ultimately results in a better product than the traditional approach of trying to build a more complex ideal project all at once.
+
+#### There are ways to make sure code is consistent and compatible while using multiple vendors.
+
+There are well-documented, standardized software development practices that can be standardized across vendors, and tools to enforce those. By adopting a “programming style” and an automated style checking tool (known as a “linter”), your vendors can ensure the code style is consistent. By adopting other automated quality-checking tools (examples include Code Climate and HoundCI), your vendors can avoid other poor code quality practices. Because the code is open source, vendors can see the code they have to integrate with. By having automated integration and unit tests, your vendors can identify and fix code that breaks or doesn't integrate as soon as it’s written.
+
+#### Onboarding vendors is more manageable when projects are modular.
+
+One of the major burdens of onboarding is the time for a vendor to understand the entirety of a project. By reducing the size of each project and simplifying the specs, the time required to onboard vendors can be reduced substantially. This makes it manageable to onboard several vendors over the course of a complex project, and reduces the risk.
+
+#### Pre-qualified agile vendor pools can help speed up modular procurement in the long run.
+
+Agile vendor pools are groups of vendors that have been pre-qualified to work on modular procurements.
+
+During the selection process, the vendor pool is asked to provide proof of their abilities through working code, rather than extensive documentation. That process can include:
+
+* Developing a programming challenge for the vendor community (for example, the challenge for Mississippi’s agile vendor pool was to build a prototype of a website that lets parents or caseworkers search for child care providers in their vicinity).
+* Defining a short period of time (days, not weeks) to build a prototype.
+* Asking for a link to the working prototype as part of their proposal, as well as a link to the public source code.
+* Evaluating the proposals based on adherence to coding and design best practices, proof they followed an agile methodology, and evidence of their user research.
+* Selecting the best-performing companies for your pool. We recommend starting with a smaller number of companies, perhaps 8 to 10. This is a manageable number, and with a defined on and off-ramp process, the size of the pool can be modified as the amount of work that can be managed increases.
+* Once your pool is created, you can write a “task order” (specific language varies from federal to state to local governments), or an RFP that only goes out to the vendors on the pool. Since they are all pre-qualified, you know they are all capable of doing the work, which lets you skip that stage of the evaluations for each subsequent RFP.

--- a/pages/open-source.md
+++ b/pages/open-source.md
@@ -1,0 +1,38 @@
+---
+layout: project-list
+title: Open source software projects
+permalink: /open-source/
+---
+
+18F has committed to working with open source software because developing in the open has real benefits, especially for the public sector. The [18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md) explains the benefits of open source and answers many common questions about security, licensing, distribution, and exceptions. Our policy is _itself_ open source, which means it can be adapted for state use.
+
+* For a primer on how to begin to work on open source software projects, our [getting started with 18F Micro-purchase](https://pages.18f.gov/micropurchase/docs/getting-started/) guide has extensive guidance and resources. It was written for potential clients of our micro-purchase platform (which allows federal agencies to purchase small amounts of open source code for integration into an existing software product), but much of the guidance applies to any open source project.
+* Our blog entry on [facts about publishing open source code in government](https://18f.gsa.gov/2016/08/08/facts-about-publishing-open-source-code-in-government/) dispels some common myths about open source software.
+
+#### Using open source software makes it easier to secure our systems and helps mitigate risks.
+
+It is our belief — generally accepted among a number of security researchers, government officials (including federal CIOs and CTOs) — that well-managed, well-written open source software can be just as secure as closed source software, if not more so.
+
+The [Department of Defense Memo on Open Source Software](http://dodcio.defense.gov/Open-Source-Software-FAQ/) has a great explanation of [why hiding source code does not automatically make source code more secure](http://dodcio.defense.gov/Open-Source-Software-FAQ/#Q:_Doesn.27t_hiding_source_code_automatically_make_software_more_secure.3F).
+
+Open source software allows defenders, researchers, and IT providers to follow best practices and work together to make the software as secure as possible.
+
+#### Open source systems are maintained much like closed source systems, but with more options for community support.
+
+Government open source systems — like closed source systems — are maintained by skilled software developers who ensure that applications, operating systems, middleware, and libraries are up-to-date and secure.
+
+In closed source systems, there are limited choices for continued development and support (often within one or several companies).
+
+We work to ensure that an open source solution can be adopted by a larger group in the open source community, to support its ongoing development with the help of a wider community.
+
+#### When you employ open source software, you are responsible for ensuring it meets your needs — just like closed source software.
+
+Open source software requires quality review and ongoing maintenance, just like closed source software. Without the appropriate expert review, the risk of unknowingly receiving buggy software is the same for both open and closed software.
+
+All software needs to be maintained and updated to continue to function, especially as technology, compliance requirements, and processes change.
+
+As with any government IT solution, closed- or open-source, the burden of ensuring the functionality, security, and operability of the solution ultimately rests with government. Open source software can provide more transparency about the health of government software, and expand options for maintainance. Working in the open can also make vendors more accountable to the software development community because their work is visible.
+
+#### Open source software supports your team’s technical skill development.
+
+If your internal team needs to develop the technical skills to evaluate, customize, and maintain modern software systems, open source solutions can provide opportunities for workforce development by ensuring access to code. This grounds technical training and talent acquisition in the actual products and processes that are used.

--- a/pages/using-cots.md
+++ b/pages/using-cots.md
@@ -1,0 +1,26 @@
+---
+layout: project-list
+title: Using commercial off-the-shelf solutions
+permalink: /using-cots/
+---
+
+In some cases, if there is a COTS system that will fit your requirements, then there may be an opportunity for cost savings.
+
+#### Fully assess whether commercial off-the-shelf (COTS) solutions fit your projects' needs.
+
+In choosing whether the COTS system is right for your project, make sure to include following factors in your analysis:
+
+* The transition from legacy systems
+* Ongoing operations and maintenance costs
+* Costs related to being locked in to a single vendor
+* Costs associated with maintaining customizations
+
+#### Modifying COTS solutions can have unexpected costs.
+
+Almost inevitably, COTS solutions require modifications in order to meet your needs. Configuring a COTS product to meet your needs is not inherently a problem, but we often see modifications to the underlying code base grow to the point where the system cannot handle any updates from the COTS provider. This poses security risks and can be a risk to the long-term viability of the tool.
+
+#### If you can already see the ways that the COTS tool does not meet your needs, it’s worth asking if your process could be adapted to meet the way the software already manages it.
+
+Alternatively, if process changes aren’t feasible, states can explore requiring the COTS provider to offer a plug-in or bridge API that would allow independently-developed custom code to meet the state's unique business need without creating unique interdependencies that will compromise the maintainability of the COTS solution.
+
+If the problem domain is core to your work and is where you would like to innovate rapidly, it will not make sense to choose COTS. On the other hand, if it is auxiliary to your work and you can adopt the process implemented by the COTS product, COTS would make sense.


### PR DESCRIPTION
Made the following changes:

* Expanded the site navigation in the header so that the individual subject pages are easier to find.
* Removed superfluous links to the FAQ landing page.
* Embedded a video in the `hero` section from CWDS, to better explain the benefits of modular procurement.
* Changed the definition of modular contracting in the `hero` section, to more closely to conform to language in FAR Part 39.

Fixes #14 